### PR TITLE
Fix exportSettings function

### DIFF
--- a/src/js/app/settingsManager.js
+++ b/src/js/app/settingsManager.js
@@ -1,3 +1,4 @@
+import browser from 'webextension-polyfill'
 import { renderColorsTab, resetAllAccents, init as initColors } from './mainColors.js'
 import { renderFontsTab, handleFontsListeners, init as initFonts } from './mainFonts.js'
 import { renderWidthsTab, handleWidthsListeners, init as initWidths } from './mainWidths.js'


### PR DESCRIPTION
## Summary
- load `webextension-polyfill` in settings manager so browser APIs are available

## Testing
- `npm run build:chrome`

------
https://chatgpt.com/codex/tasks/task_e_688461d872f8832d8e8031b40d77498e