### PR TITLE
Fix browser polyfill

### DIFF
--- a/src/js/browser.js
+++ b/src/js/browser.js
@@ -1,8 +1,14 @@
 import webextension from 'webextension-polyfill'
 
-// Use the polyfill if available. Otherwise fall back to global objects.
-const browser = webextension ||
-                (typeof globalThis !== 'undefined' && globalThis.browser) ||
-                (typeof globalThis !== 'undefined' && globalThis.chrome)
+// Use polyfill when available, otherwise fall back to global objects.
+const browserObj =
+        webextension ||
+        (typeof globalThis !== 'undefined' &&
+                (globalThis.browser || globalThis.chrome))
 
-export default browser
+// Ensure a `browser` global exists so bundled scripts can access it
+if (typeof globalThis !== 'undefined' && browserObj && !globalThis.browser) {
+        globalThis.browser = browserObj
+}
+
+export default browserObj


### PR DESCRIPTION
## Summary
- update browser polyfill to always expose a global `browser`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6884de042acc832daf451a6743ac0f72